### PR TITLE
Include "explicit" tag in Deemix config file

### DIFF
--- a/playlist_sync/deemix_config.py
+++ b/playlist_sync/deemix_config.py
@@ -63,7 +63,7 @@ DEFAULT_CONFIG = {
     "genre": True,
     "year": True,
     "date": True,
-    "explicit": False,
+    "explicit": True,
     "isrc": True,
     "length": True,
     "barcode": True,


### PR DESCRIPTION
I occasionally need to make sure I've got the "clean" version of a song (or I want the "explicit" one for personal listening).

This will add the "explicit" tag to Deemix's downloads, showing as "ITUNESADVISORY = 1" in the extended tags for a given file (0 for "clean" tracks). Including this tag will allow users to filter/tag explicit tracks using [beets](https://beets.io/) (or other tag-editing software), making them easier to sort in a media player or DJ software.

![Screen Shot 2023-04-14 at 15 21 07](https://user-images.githubusercontent.com/22822291/232157081-687dac69-feb5-40ff-b060-cffa8d170fd3.png)